### PR TITLE
Added new editorconfig rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ max_line_length = 100
 trim_trailing_whitespace = true
 
 [*.py]
-indent_size = 12
+indent_size = 4
 trim_trailing_whitespace = true
 end_of_line = LF
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,19 +7,19 @@ end_of_line = lf
 indent_size = 2
 indent_style = space
 insert_final_newline = true
-max_line_length = 80
+max_line_length = 100
 trim_trailing_whitespace = true
 
 [*.py]
-indent_style = space
-indent_size = 4
+indent_size = 12
 trim_trailing_whitespace = true
 end_of_line = LF
 
-# trailing spaces in markdown indicate word wrap
+[*.js]
+indent_size = 2
+
 [*.md]
 trim_trailing_spaces = false
-max_line_length = 80
 
 [COMMIT_EDITMSG]
 max_line_length = 0


### PR DESCRIPTION
Added new editorconfig rules for js specificity, changed max line length, deleted redundant rules. 

After experimenting I learned that the editorconfig extension is definitely required in order for it to work correctly so this is something we'll have to address for everyone.
@ZakkMan 