### PR TITLE
Added size prop so that modifier can be used PR

### DIFF
--- a/client/src/components/Icon/Icon.js
+++ b/client/src/components/Icon/Icon.js
@@ -5,7 +5,7 @@ import "./Icon.css";
 
 const Icon = (props) => (
   <div>
-    <FontAwesomeIcon icon={ props.icon} />
+    <FontAwesomeIcon icon={ props.icon} size={props.size}/>
   </div>
 )
 


### PR DESCRIPTION
This is the icon library from issue #74. To use any of the modifiers per the documentation, a prop for each of them needs to be added to the component so that they can be used. I currently just need to access the size modifier but there are others. If others are needed, I think they'll need a separate prop. I tested it out and it works.

```
<FontAwesomeIcon icon="spinner" size="xs" />
<FontAwesomeIcon icon="spinner" size="lg" />
<FontAwesomeIcon icon="spinner" size="6x" />
```

I'll update the Readme to reflect this once this PR is approved.