### PR TITLE
The Link was missng from the main menu item in Navlink - Hotfix

### DIFF
--- a/client/src/components/NavLink/NavLink.js
+++ b/client/src/components/NavLink/NavLink.js
@@ -26,7 +26,9 @@ class NavLink extends React.Component {
         onMouseLeave={this.toggleDropdown}
       >
         <div>
-          <h1>{this.props.text}</h1>
+          <Link to={this.props.to} >
+            <h1>{this.props.text}</h1>
+          </Link>
           <div
             className={
               this.state.dropdownVisible


### PR DESCRIPTION
I'm fairly sure that there used to be a Link attached to the main menu item but it's no longer there. I added it in so that functionality has returned.