### PR TITLE
Escalation templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,13 @@
+Related Issue(s):
+
+Expected Behavior:
+
+Description of bug:
+
+Troubleshooting performed:
+
+Screenshot(s):
+
+Code that you expect is causing bug:
+
+_Please add appropriate label and link pull requests if applicable_

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,11 @@
+Related Issue(s):
+
+Have you confirmed that there is not already an open issue for this?
+
+Reason for request:
+
+Expected behavior:
+
+User story:
+
+_Please add appropriate label and link pull requests if applicable_

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,9 @@
+- Related Issue (include '#'):
+
+- Description of changes made:
+
+- Is the feature complete/bug resolved/etc..:
+
+- Any known bugs/strange behavior:
+
+- Is there specific feedback you would like on these changes:

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,9 +1,0 @@
-- Related Issue (include '#'):
-
-- Description of changes made:
-
-- Is the feature complete/bug resolved/etc..:
-
-- Any known bugs/strange behavior:
-
-- Is there specific feedback you would like on these changes:

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,9 @@
+- Related Issue (include '#'):
+
+- Description of changes made:
+
+- Is the feature complete/bug resolved/etc..:
+
+- Any known bugs/strange behavior:
+
+- Is there specific feedback you would like on these changes:


### PR DESCRIPTION
Issue: #416 

If I understood the documentation correctly - I created a hidden .github directory at the root level and included a `ISSUE_TEMPLATE` subdirectory with two different templates, as well as a `PULL_REQUEST_TEMPLATE` subdir with just the singular template. Let me know if I need to change the file structure or any other changes you'd like me to make to the templates themselves.