### PR TITLE
Updated Onboarding Page & Onboarding Pills Responsiveness

### DIFF
--- a/client/src/components/OnboardingPills/OnboardingPills.css
+++ b/client/src/components/OnboardingPills/OnboardingPills.css
@@ -4,3 +4,15 @@
   justify-content: center;
   width: 34.6rem;
 }
+
+@media only screen and (max-width: 800px) {
+  .OnboardingPills {
+    width: 25rem;
+  }
+}
+
+@media only screen and (max-width: 400px) {
+  .OnboardingPills {
+    width: 20rem;
+  }
+}

--- a/client/src/pages/OnboardingPage/OnboardingPage.css
+++ b/client/src/pages/OnboardingPage/OnboardingPage.css
@@ -2,7 +2,7 @@
   font-family: var(--default-font);
   background: linear-gradient(180deg, rgba(255, 255, 255, 0) 72.4%, rgba(255, 255, 255, 0.75) 100%),
     #ffcb08;
-  height: 110vh;
+  min-height: 100vh;
   width: 100vw;
   display: flex;
 }
@@ -55,6 +55,7 @@
 }
 .OnboardingPage__text {
   text-align: center;
+  padding: 0 10px;
 }
 .OnboardingPage__spacer {
   height: 1rem;


### PR DESCRIPTION
- Related Issue (include '#'): #480 

- Description of changes made: changed height of onboarding page wrapped to be a minimum of 100vh, as it was initial set to be a fixed height of 110vh, causing the box to spill out at certain screen sizes. Added responsive widths to the Onboarding Pills so that they are all viewable at different screen sizes

- Is the feature complete/bug resolved/etc..: Yes

- Screenshot(s):
<img width="342" alt="Screen Shot 2020-04-01 at 15 13 01" src="https://user-images.githubusercontent.com/57416150/78177050-7b57f880-742b-11ea-8665-2d4ae714d617.png">
<img width="362" alt="Screen Shot 2020-04-01 at 15 12 25" src="https://user-images.githubusercontent.com/57416150/78177051-7bf08f00-742b-11ea-8272-4891e2284ddb.png">


