### PR TITLE
add netlify to CORS whitelist

### DIFF
--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -66,9 +66,11 @@ CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_CREDENTIALS = True
 CORS_ORIGIN_WHITELIST = [
     'http://localhost:3000',
+    'https://cotripper.netlify.com'
 ]
 CORS_ORIGIN_REGEX_WHITELIST = [
     'http://localhost:3000',
+    'https://cotripper.netlify.com'
 ]
 
 ROOT_URLCONF = 'api.urls'


### PR DESCRIPTION
- Related Issue (include '#'): none

- Description of changes made: added netlify to CORS whitelist because file uploading isn't working on deployed site 
