### PR TITLE
fixed link on BookTripCard to route to correct path

### DIFF
--- a/client/src/components/BookTripCard/BookTripCard.js
+++ b/client/src/components/BookTripCard/BookTripCard.js
@@ -24,6 +24,6 @@ const BookTripCard = props => {
 };
 BookTripCard.defaultProps = {
   children: [<h1>Book a Trip</h1>, <Card size="medium-small" />, <Card size="medium-small" />],
-  link: "/"
+  link: "/book-a-trip"
 };
 export default BookTripCard;


### PR DESCRIPTION
- Related Issue (include '#'):
The link in the BookTrip Card in the /home route was not doing anything when clicked on
- Description of changes made:
changed the link attribute in the defaultProps of theBookTripCard component
- Is the feature complete/bug resolved/etc..:
resolved
- Any known bugs/strange behavior:
n./a
- Is there specific feedback you would like on these changes:
any feedback is welcomed
- Screenshot(s):
