### PR TITLE
solved css bug

### DIFF
--- a/client/src/components/GroupCard/GroupCard.css
+++ b/client/src/components/GroupCard/GroupCard.css
@@ -31,7 +31,7 @@
   justify-content: space-around;
   font-size: 1rem;
   font-weight: bold;
-  margin-top: -10px;
+  margin-top: 30px;
 }
 
 .GroupCard__members {


### PR DESCRIPTION
- Related Issue (include '#'): #691

- Description of changes made: modified CSS to ensure text does not overlap and remain on the card.

- Is the feature complete/bug resolved/etc..:

- Any known bugs/strange behavior:  None at the moment, programmed responded well to screen size modifications

- Is there specific feedback you would like on these changes:

- Screenshot(s):
